### PR TITLE
Feat: Add a list of attackers IP's

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ attack settings:
                         Set the attackers geo by 2 letter region. Use RD for random (default: RD)
   --attacker-user-agent ATTACKER_USER_AGENT
                         Set the attackers user-agent. Use RD for random (default: RD)
+  --additional-attacker-ips ADDITIONAL_ATTACKER_IPS
+                        Additional attackers ip addresses, comma separated (default: ). If you wish to exclusively use this list set spoofed-attacks to 0
 ```
 
 ### Examples
@@ -152,6 +154,12 @@ The following example will create a set of logs and output the attackers IP addr
 
 ```
 python pwnspoof.py banking --spoofed-attacks 3 --iocs 
+```
+
+The following example will create a set of logs and exclusively use the IP addresses specified
+
+```
+python pwnspoof.py banking --spoofed-attacks 0 --additional-attacker-ips 192.168.0.1,192.168.0.2
 ```
 
 ## Demo

--- a/pwnspoof.py
+++ b/pwnspoof.py
@@ -211,7 +211,7 @@ for x in range(0, args.spoofed_attacks):
     attack.chosen_attack_payloads = []
     sh.add_session(attack)
     attacker_sessions.append(attack)
-## Convert args.attacker_ips to list
+
 if args.attacker_ips != "":
     attacker_ips = args.attacker_ips.split(",")
     for ip in attacker_ips:

--- a/pwnspoof.py
+++ b/pwnspoof.py
@@ -122,10 +122,10 @@ attack_settings.add_argument(
     help="Set the attackers user-agent.  Use RD for random (default: %(default)s)",
 )
 attack_settings.add_argument(
-    "--attacker-ips",
+    "--additional-attacker-ips",
     type=str,
     default="",
-    help="Inject a set of attackers ip addresses, comma separated (default: %(default)s)",
+    help="Additional attackers ip addresses, comma separated (default: %(default)s). If you wish to exclusively use this list set spoofed-attacks to 0",
 )
 try:
     args = parser.parse_args()
@@ -212,8 +212,9 @@ for x in range(0, args.spoofed_attacks):
     sh.add_session(attack)
     attacker_sessions.append(attack)
 
-if args.attacker_ips != "":
-    attacker_ips = args.attacker_ips.split(",")
+if args.additional_attacker_ips != "":
+    attacker_ips = args.additional_attacker_ips.split(",")
+    print("Injecting {} additional attack sessions".format(len(attacker_ips)))
     for ip in attacker_ips:
         attack_start_date = (random.choice(sh.sessions)).start_datetime
         attack = Session(

--- a/pwnspoof.py
+++ b/pwnspoof.py
@@ -121,6 +121,12 @@ attack_settings.add_argument(
     default="RD",
     help="Set the attackers user-agent.  Use RD for random (default: %(default)s)",
 )
+attack_settings.add_argument(
+    "--attacker-ips",
+    type=str,
+    default="",
+    help="Inject a set of attackers ip addresses, comma separated (default: %(default)s)",
+)
 try:
     args = parser.parse_args()
 except SystemExit as e:
@@ -205,6 +211,23 @@ for x in range(0, args.spoofed_attacks):
     attack.chosen_attack_payloads = []
     sh.add_session(attack)
     attacker_sessions.append(attack)
+## Convert args.attacker_ips to list
+if args.attacker_ips != "":
+    attacker_ips = args.attacker_ips.split(",")
+    for ip in attacker_ips:
+        attack_start_date = (random.choice(sh.sessions)).start_datetime
+        attack = Session(
+            attack_start_date,
+            list(apps[args.app].attacks[args.attack_type]()),
+            user_agent=attacker_user_agent,
+            username=random.choice(sh.sessions).username,
+            source_ip=ip,
+            app=apps[args.app],
+        )
+        attack.attack_payloads = []
+        attack.chosen_attack_payloads = []
+        sh.add_session(attack)
+        attacker_sessions.append(attack)
 ## Generate and output
 
 print("Generating the logz and writing them to '{}'".format(args.out))


### PR DESCRIPTION
Hey all,

I needed the ability to define a set list of attacker IP's so I can showcase our CTI data as well as the random attacker IP's as well. Didn't know if it would be useful to merge upstream, I have tested all outputs and cannot see if it conflicts with anything as the main thing that isnt set is the GEO as it doesnt go back to lookup the geo of an IP.

If you dont want to merge something like this I can keep my fork as it handles my use case but thanks for making this awesome project!

Here is an example command:

```
python pwnspoof.py wordpress --session-count 10 --spoofed-attacks 0 --attacker-ips 185.213.9.10,85.215.211.68  --attack-type command_injection --server-fqdn marysfarm.local --out pwn.log --server-type NGINX
```