### PR TITLE
initial container support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github
+images
+test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 pwnspoof.log
 launch.json
 /ignore
+output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM python:alpine
 
-COPY ./* /app/
+COPY *.py /app/
+
+COPY IP2LOCATION-LITE-DB1.CSV /app/
+
+COPY docker_start.sh /app/
 
 WORKDIR /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:alpine
+
+COPY ./* /app/
+
+WORKDIR /app/
+
+RUN mkdir /output/
+
+ENTRYPOINT [ "/app/docker_start.sh" ]

--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ python pwnspoof.py banking --spoofed-attacks 0 --additional-attacker-ips 192.168
 
 [![Demo](/images/pwnspoof.gif)](#Demo)
 
+## Container Support
+
+Build the container
+
+```
+podman built -t pwnspoof .
+```
+
+Then you can generate logs via the container with the following command (This is presuming you build the container with the tag pwnspoof)
+
+```
+podman run -v ./pwnspoof.log:/output/pwnspoof.log pwnspoof banking
+```
+
 ## Road Map
 
 pwnSpoof is built to produce to authentic web attack logs and it does this really well.  Right now we are focused on refactoring the code, building out our testing suite and getting the first push to PyPi but we have *huge* ambitions for pwnSpoof.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ podman built -t pwnspoof .
 Then you can generate logs via the container with the following command (This is presuming you build the container with the tag pwnspoof)
 
 ```
+## touch pwnspoof.log
 podman run -v ./pwnspoof.log:/output/pwnspoof.log pwnspoof banking
 ```
 

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,0 +1,4 @@
+#!/bin/ash
+cd /app/ || exit 1 
+
+python pwnspoof.py "$@" --out "${OUTPUT:-/output/pwnspoof.log}"


### PR DESCRIPTION
Add a dockerfile so users can self build if needed rather than installing python, added example how to run.

I tried getting /dev/stdout support but something a little bit odd. So I thought ill do a quick start for #32 then we expand further.

Maybe we could add a build path for punk-security dockerhub but 🤷🏻 I leave that to you to decide